### PR TITLE
Fix memory load with limited bit width

### DIFF
--- a/Sources/WAKit/Execution/Instructions/Memory.swift
+++ b/Sources/WAKit/Execution/Instructions/Memory.swift
@@ -1,14 +1,20 @@
 /// - Note:
 /// <https://webassembly.github.io/spec/core/exec/instructions.html#memory-instructions>
 extension InstructionFactory {
-    func load<V: Value & ByteConvertible>(_ type: V.Type, _ offset: UInt32) -> Instruction {
+    func load<V: Value & ByteConvertible>(
+        _ type: V.Type,
+        bitWidth: Int? = nil,
+        isSigned: Bool = true,
+        _ offset: UInt32
+    ) -> Instruction {
+        // FIXME: handle `isSigned`
         return makeInstruction { pc, store, stack in
             let frame = try stack.get(current: Frame.self)
             let memoryAddress = frame.module.memoryAddresses[0]
             let memoryInstance = store.memories[memoryAddress]
             let i = try stack.pop(I32.self).rawValue
             let address = Int(offset + i)
-            let length = type.bitWidth / 8
+            let length = (bitWidth ?? type.bitWidth) / 8
             guard memoryInstance.data.indices.contains(address + length) else {
                 throw Trap.memoryOverflow
             }

--- a/Sources/WAKit/Execution/Types/Instances.swift
+++ b/Sources/WAKit/Execution/Types/Instances.swift
@@ -45,7 +45,7 @@ final class TableInstance {
 /// - Note:
 /// <https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances>
 final class MemoryInstance {
-    private static let pageSize = 6 * 1024
+    private static let pageSize = 64 * 1024
 
     var data: [UInt8]
     let max: UInt32?

--- a/Sources/WAKit/Parser/Wasm/WasmParser.swift
+++ b/Sources/WAKit/Parser/Wasm/WasmParser.swift
@@ -303,55 +303,55 @@ extension WasmParser {
         case .i64_load:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, offset)]
         case .f32_load:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(F32.self, offset)]
         case .f64_load:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(F64.self, offset)]
         case .i32_load8_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I32.self, bitWidth: 8, isSigned: true, offset)]
         case .i32_load8_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I32.self, bitWidth: 8, isSigned: false, offset)]
         case .i32_load16_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I32.self, bitWidth: 16, isSigned: true, offset)]
         case .i32_load16_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I32.self, bitWidth: 16, isSigned: false, offset)]
         case .i64_load8_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 8, isSigned: true, offset)]
         case .i64_load8_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 8, isSigned: false, offset)]
         case .i64_load16_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 16, isSigned: true, offset)]
         case .i64_load16_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 16, isSigned: false, offset)]
         case .i64_load32_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 32, isSigned: true, offset)]
         case .i64_load32_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 16, isSigned: false, offset)]
         case .i32_store:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
@@ -359,7 +359,7 @@ extension WasmParser {
         case .i64_store:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .f32_store:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
@@ -367,7 +367,7 @@ extension WasmParser {
         case .f64_store:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .i32_store8:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
@@ -379,15 +379,15 @@ extension WasmParser {
         case .i64_store8:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .i64_store16:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .i64_store32:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .memory_size:
             let zero = try stream.consumeAny()
             guard zero == 0x00 else {

--- a/Tests/WAKitTests/Execution/Instructions/ControlInstructionTests.swift
+++ b/Tests/WAKitTests/Execution/Instructions/ControlInstructionTests.swift
@@ -249,4 +249,28 @@ final class ControlInstructionTests: XCTestCase {
             Instruction.Action.invoke(0)
         )
     }
+
+    func testLoad() {
+        let memory = MemoryInstance(.init(min: 1, max: nil))
+        memory.data[0..<3] = [97, 98, 99, 100] // ASCII "abcd"
+        store.memories.append(memory)
+
+        let module = ModuleInstance()
+        module.memoryAddresses = [0]
+
+        let frame = Frame(arity: 0, module: module, locals: [])
+        stack.push(frame)
+        stack.push(I32(0))
+
+        let instruction = InstructionFactory(code: .i32_load8_u).load(I32.self, bitWidth: 8, isSigned: false, 0)
+        XCTAssertEqual(instruction.code, .i32_load8_u)
+
+        let expression = Expression(instructions: [instruction])
+        XCTAssertEqual(
+            try expression.execute(address: 0, store: store, stack: &stack),
+            Instruction.Action.jump(1)
+        )
+
+        XCTAssertEqual(stack, [I32(97), frame])
+    }
 }


### PR DESCRIPTION
This change fixes `load` instructions not respecting bit width parts. For example, `i32.load8_u` was loading all i32 bytes instead of a single byte.

Also, the page size was specified as 6K, while it's 64K according to the spec.

This increases the amount of spec tests passing from 25% in `master` to 33% in this branch.