### PR TITLE
Print passing/total counts of test cases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Test in Debug
         run: |
           swift test -c debug
-          make testspec
+          make spectest
 
   build-linux:
     runs-on: ubuntu-20.04
@@ -25,4 +25,4 @@ jobs:
       - name: Test in Debug
         run: |
           swift test -c debug
-          make testspec
+          make spectest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,15 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
       - name: Test in Debug
-        run: swift test -c debug
+        run: |
+          swift test -c debug
+          make testspec
 
   build-linux:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Test in Debug
-        run: swift test -c debug
+        run: |
+          swift test -c debug
+          make testspec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       # Checks-out the repo. More at: https://github.com/actions/checkout
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Select Xcode version
         run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
       - name: Test in Debug
@@ -22,6 +24,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Test in Debug
         run: |
           swift test -c debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Test in Debug
         run: |
           swift test -c debug
+
+          brew install wabt
           make spectest
 
   build-linux:
@@ -29,4 +31,8 @@ jobs:
       - name: Test in Debug
         run: |
           swift test -c debug
+
+          curl -L -v -o wabt.tar.gz https://github.com/WebAssembly/wabt/releases/download/1.0.24/wabt-1.0.24-ubuntu.tar.gz
+          tar xzvf wabt.tar.gz
+          cp wabt-1.0.24/bin/* /usr/local/bin
           make spectest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,8 @@ jobs:
         run: |
           swift test -c debug
 
-          curl -L -v -o wabt.tar.gz https://github.com/WebAssembly/wabt/releases/download/1.0.24/wabt-1.0.24-ubuntu.tar.gz
-          tar xzvf wabt.tar.gz
-          cp wabt-1.0.24/bin/* /usr/local/bin
-          make spectest
+          # Disabled on Linux due to unexplained crashes.
+          # curl -L -v -o wabt.tar.gz https://github.com/WebAssembly/wabt/releases/download/1.0.24/wabt-1.0.24-ubuntu.tar.gz
+          # tar xzvf wabt.tar.gz
+          # cp wabt-1.0.24/bin/* /usr/local/bin
+          # make spectest

--- a/Sources/CLI/SpecTest/SpecTestCommand.swift
+++ b/Sources/CLI/SpecTest/SpecTestCommand.swift
@@ -20,6 +20,7 @@ final class SpecTestCommand: Command {
             fatalError("failed to load test: \(error)")
         }
 
+        var results = [Result]()
         for testCase in testCases {
             testCase.run(rootPath: path.value) { testCase, command, result in
                 switch result {
@@ -30,7 +31,11 @@ final class SpecTestCommand: Command {
                 default:
                     print("\(testCase.sourceFilename):\(command.line):", result.banner)
                 }
+                results.append(result)
             }
         }
+
+        let passingCount = results.filter { if case .passed = $0 { return true } else { return false} }.count
+        print("\(passingCount)/\(results.count) \(Int(Double(passingCount)/Double(results.count) * 100))% passing")
     }
 }

--- a/Sources/CLI/SpecTest/TestCase.swift
+++ b/Sources/CLI/SpecTest/TestCase.swift
@@ -227,7 +227,9 @@ extension TestCase.Command {
             switch $0.type {
             case .i32: return I32(UInt32($0.value)!)
             case .i64: return I64(UInt64($0.value)!)
+            case .f32 where $0.value.starts(with: "nan:"): return F32(Float32.nan)
             case .f32: return F32(Float32($0.value)!)
+            case .f64 where $0.value.starts(with: "nan:"): return F64(Float64.nan)
             case .f64: return F64(Float64($0.value)!)
             }
         }
@@ -238,7 +240,9 @@ extension TestCase.Command {
             switch $0.type {
             case .i32: return I32(UInt32($0.value!)!)
             case .i64: return I64(UInt64($0.value!)!)
+            case .f32 where $0.value!.starts(with: "nan:"): return F32(Float32.nan)
             case .f32: return F32(Float32($0.value!)!)
+            case .f64 where $0.value!.starts(with: "nan:"): return F64(Float64.nan)
             case .f64: return F64(Float64($0.value!)!)
             }
         }

--- a/Sources/WAKit/Execution/Instructions/Memory.swift
+++ b/Sources/WAKit/Execution/Instructions/Memory.swift
@@ -1,14 +1,20 @@
 /// - Note:
 /// <https://webassembly.github.io/spec/core/exec/instructions.html#memory-instructions>
 extension InstructionFactory {
-    func load<V: Value & ByteConvertible>(_ type: V.Type, _ offset: UInt32) -> Instruction {
+    func load<V: Value & ByteConvertible>(
+        _ type: V.Type,
+        bitWidth: Int? = nil,
+        isSigned: Bool = true,
+        _ offset: UInt32
+    ) -> Instruction {
+        // FIXME: handle `isSigned`
         return makeInstruction { pc, store, stack in
             let frame = try stack.get(current: Frame.self)
             let memoryAddress = frame.module.memoryAddresses[0]
             let memoryInstance = store.memories[memoryAddress]
             let i = try stack.pop(I32.self).rawValue
             let address = Int(offset + i)
-            let length = type.bitWidth / 8
+            let length = (bitWidth ?? type.bitWidth) / 8
             guard memoryInstance.data.indices.contains(address + length) else {
                 throw Trap.memoryOverflow
             }

--- a/Sources/WAKit/Execution/Types/Instances.swift
+++ b/Sources/WAKit/Execution/Types/Instances.swift
@@ -45,7 +45,7 @@ final class TableInstance {
 /// - Note:
 /// <https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances>
 final class MemoryInstance {
-    private static let pageSize = 6 * 1024
+    private static let pageSize = 64 * 1024
 
     var data: [UInt8]
     let max: UInt32?

--- a/Sources/WAKit/Parser/Wasm/WasmParser.swift
+++ b/Sources/WAKit/Parser/Wasm/WasmParser.swift
@@ -303,55 +303,55 @@ extension WasmParser {
         case .i64_load:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, offset)]
         case .f32_load:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(F32.self, offset)]
         case .f64_load:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(F64.self, offset)]
         case .i32_load8_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I32.self, bitWidth: 8, isSigned: true, offset)]
         case .i32_load8_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I32.self, bitWidth: 8, isSigned: false, offset)]
         case .i32_load16_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I32.self, bitWidth: 16, isSigned: true, offset)]
         case .i32_load16_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I32.self, bitWidth: 16, isSigned: false, offset)]
         case .i64_load8_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 8, isSigned: true, offset)]
         case .i64_load8_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 8, isSigned: false, offset)]
         case .i64_load16_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 16, isSigned: true, offset)]
         case .i64_load16_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 16, isSigned: false, offset)]
         case .i64_load32_s:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 32, isSigned: true, offset)]
         case .i64_load32_u:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.load(I32.self, offset)]
+            return [factory.load(I64.self, bitWidth: 16, isSigned: false, offset)]
         case .i32_store:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
@@ -359,7 +359,7 @@ extension WasmParser {
         case .i64_store:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .f32_store:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
@@ -367,7 +367,7 @@ extension WasmParser {
         case .f64_store:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .i32_store8:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
@@ -379,15 +379,15 @@ extension WasmParser {
         case .i64_store8:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .i64_store16:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .i64_store32:
             let _: UInt32 = try parseUnsigned()
             let offset: UInt32 = try parseUnsigned()
-            return [factory.store(I32.self, offset)]
+            return [factory.store(I64.self, offset)]
         case .memory_size:
             let zero = try stream.consumeAny()
             guard zero == 0x00 else {

--- a/Tests/WAKitTests/Execution/Instructions/ControlInstructionTests.swift
+++ b/Tests/WAKitTests/Execution/Instructions/ControlInstructionTests.swift
@@ -249,4 +249,28 @@ final class ControlInstructionTests: XCTestCase {
             Instruction.Action.invoke(0)
         )
     }
+
+    func testLoad() {
+        let memory = MemoryInstance(.init(min: 1, max: nil))
+        memory.data[0..<3] = [97, 98, 99, 100] // ASCII "abcd"
+        store.memories.append(memory)
+
+        let module = ModuleInstance()
+        module.memoryAddresses = [0]
+
+        let frame = Frame(arity: 0, module: module, locals: [])
+        stack.push(frame)
+        stack.push(I32(0))
+
+        let instruction = InstructionFactory(code: .i32_load8_u).load(I32.self, bitWidth: 8, isSigned: false, 0)
+        XCTAssertEqual(instruction.code, .i32_load8_u)
+
+        let expression = Expression(instructions: [instruction])
+        XCTAssertEqual(
+            try expression.execute(address: 0, store: store, stack: &stack),
+            Instruction.Action.jump(1)
+        )
+
+        XCTAssertEqual(stack, [I32(97), frame])
+    }
 }


### PR DESCRIPTION
Now the `spectest` command prints a summary after the test run has completed in this form:

```
6309/19331 32% passing
```

I've also fixed `nan` values not being parsed in test cases.